### PR TITLE
Implementazione pagina log azioni utenti

### DIFF
--- a/CRM/dashboard.php
+++ b/CRM/dashboard.php
@@ -128,6 +128,10 @@ $user_role_display = htmlspecialchars(isset($_SESSION['ruolo']) ? $_SESSION['ruo
                     <div class="tool-card-header"><div class="tool-card-icon">👤</div><h3 class="tool-card-title">Gestione Utenze</h3></div>
                     <p class="tool-card-description">Crea, visualizza e modifica gli utenti del sistema.</p>
                 </a>
+                <a href="logs.php" class="tool-card">
+                    <div class="tool-card-header"><div class="tool-card-icon">🗒️</div><h3 class="tool-card-title">Log Azioni</h3></div>
+                    <p class="tool-card-description">Visualizza le azioni degli utenti e filtra per utente o data.</p>
+                </a>
             </div>
         <?php endif; ?>
 

--- a/CRM/db_deploy.sql
+++ b/CRM/db_deploy.sql
@@ -128,6 +128,17 @@ INSERT INTO `utenti` (`id`, `username`, `email`, `nome`, `password_hash`, `ruolo
 	(1, 'admin', 'admin@gruppovitolo.example.com', 'admin', '$2y$10$9RMP49bT0CRS9I.MXuIa7ek2SHfovBVWezAMjYvXTyz5oq.2EV3NO', 'admin', '2025-06-06 07:36:44'),
 	(2, 'users', '', 'users', '$2y$10$jCb4tU2C6hc99e4gFJUCTePCTwJhtK7BuK1lF046bJrscFDw4ikVi', 'user', '2025-06-06 07:36:44');
 
+CREATE TABLE IF NOT EXISTS `user_logs` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
+  `username` varchar(50) DEFAULT NULL,
+  `action` varchar(100) NOT NULL,
+  `details` text DEFAULT NULL,
+  `action_time` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `user_id` (`user_id`),
+  CONSTRAINT `user_logs_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `utenti`(`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 /*!40103 SET TIME_ZONE=IFNULL(@OLD_TIME_ZONE, 'system') */;
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 /*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;

--- a/CRM/log_helpers.php
+++ b/CRM/log_helpers.php
@@ -1,0 +1,22 @@
+<?php
+require_once 'db_config.php';
+function log_action($user_id, $username, $action, $details = null) {
+    global $db_host, $db_user, $db_pass, $db_name, $db_port;
+    $conn = isset($db_port)
+        ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port)
+        : new mysqli($db_host, $db_user, $db_pass, $db_name);
+    if ($conn->connect_error) {
+        error_log('[log_action] DB connection error: ' . $conn->connect_error);
+        return;
+    }
+    $stmt = $conn->prepare("INSERT INTO user_logs (user_id, username, action, details) VALUES (?, ?, ?, ?)");
+    if ($stmt) {
+        $stmt->bind_param('isss', $user_id, $username, $action, $details);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        error_log('[log_action] Prepare failed: ' . $conn->error);
+    }
+    $conn->close();
+}
+?>

--- a/CRM/login.php
+++ b/CRM/login.php
@@ -11,11 +11,9 @@ ini_set('display_errors', 0);
 ini_set('log_errors', 1);
 ini_set('error_log', 'C:/xampp/php_error.log');
 
-$db_host = 'localhost';
-$db_user = 'root';
-$db_pass = '';
-$db_name = 'gruppo_vitolo_db';
-$login_error = '';
+require_once "db_config.php";
+require_once "log_helpers.php";
+$login_error = "";
 
 error_log("--- Inizio tentativo di login (con ruoli) --- [" . date("Y-m-d H:i:s") . "]");
 
@@ -48,6 +46,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) {
                         $_SESSION['username'] = $db_username;
                         $_SESSION['ruolo'] = $db_ruolo;
                         $_SESSION['user_fullname'] = $db_user_fullname;
+                        log_action($user_id, $db_username, "login", "Login effettuato");
                         header("Location: dashboard.php");
                         exit;
                     } else {

--- a/CRM/logout.php
+++ b/CRM/logout.php
@@ -1,5 +1,9 @@
 <?php
 session_start(); // Accedi alla sessione
+require_once "log_helpers.php";
+$uid = $_SESSION["user_id"] ?? null;
+$uname = $_SESSION["username"] ?? "";
+log_action($uid, $uname, "logout", "Logout");
 session_unset(); // Rimuovi tutte le variabili di sessione
 session_destroy(); // Distruggi la sessione
 header("Location: login.php"); // Reindirizza alla pagina di login

--- a/CRM/logs.php
+++ b/CRM/logs.php
@@ -1,0 +1,157 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+ini_set('log_errors', 1);
+ini_set('error_log', 'C:/xampp/php_error.log');
+error_reporting(E_ALL);
+
+$ruolo_admin_atteso = 'admin';
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['ruolo']) || $_SESSION['ruolo'] !== $ruolo_admin_atteso) {
+    header("Location: login.php");
+    exit;
+}
+
+$username_display = htmlspecialchars($_SESSION['username'] ?? '');
+$user_role_display = htmlspecialchars($_SESSION['ruolo'] ?? '');
+
+$filter_user = trim($_GET['user'] ?? '');
+$filter_action = trim($_GET['action'] ?? '');
+$filter_from = $_GET['from'] ?? '';
+$filter_to = $_GET['to'] ?? '';
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+$logs = [];
+$db_error_message = null;
+if ($conn->connect_error) {
+    $db_error_message = "Errore di connessione al database.";
+} else {
+    $sql = "SELECT id, user_id, username, action, details, action_time FROM user_logs WHERE 1";
+    $params = [];
+    $types = '';
+    if ($filter_user !== '') { $sql .= " AND username LIKE ?"; $params[] = "%$filter_user%"; $types .= 's'; }
+    if ($filter_action !== '') { $sql .= " AND action LIKE ?"; $params[] = "%$filter_action%"; $types .= 's'; }
+    if ($filter_from !== '') { $sql .= " AND action_time >= ?"; $params[] = $filter_from . ' 00:00:00'; $types .= 's'; }
+    if ($filter_to !== '') { $sql .= " AND action_time <= ?"; $params[] = $filter_to . ' 23:59:59'; $types .= 's'; }
+    $sql .= " ORDER BY action_time DESC LIMIT 100";
+    $stmt = $conn->prepare($sql);
+    if ($stmt) {
+        if (!empty($types)) $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($row = $result->fetch_assoc()) {
+            $logs[] = $row;
+        }
+        $stmt->close();
+    }
+    $conn->close();
+}
+?>
+<!DOCTYPE html>
+<html lang="it">
+<head>
+    <meta charset="UTF-8">
+    <title>Log Azioni Utenti</title>
+    <style>
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f8f9fa; margin:0; padding:0; }
+        .page-outer-container { max-width: 1200px; margin: 20px auto; padding:0 15px; }
+        .module-header { display:flex; justify-content:space-between; align-items:center; background-color:#fff; padding:20px 30px; border-radius:12px; box-shadow:0 4px 15px rgba(0,0,0,0.06); border-bottom:5px solid #B08D57; margin-bottom:30px; }
+        .header-branding{ display:flex; align-items:center; }
+        .header-branding .logo{ max-height:55px; margin-right:20px; }
+        .header-titles h1{ font-size:1.6em; color:#2E572E; margin:0; font-weight:600; }
+        .header-titles h2{ font-size:1em; color:#6c757d; margin:0; font-weight:400; }
+        .user-session-controls{ text-align:right; font-size:0.9em; color:#555; display:flex; align-items:center; gap:15px; }
+        .user-session-controls .nav-link-button, .user-session-controls .logout-button{ padding:8px 16px; font-size:0.9em; text-decoration:none; border-radius:5px; }
+        .user-session-controls .nav-link-button{ background-color:#6c757d; color:#fff; }
+        .user-session-controls .logout-button{ background-color:#D42A2A; color:#fff; }
+        .filter-form{ margin-bottom:20px; background:#fff; padding:20px; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.05); display:flex; gap:20px; align-items:flex-end; }
+        .filter-form .filter-group{ display:flex; flex-direction:column; }
+        .filter-form label{ font-weight:600; margin-bottom:5px; font-size:0.9em; }
+        .filter-form input{ padding:8px; border:1px solid #ccc; border-radius:4px; }
+        table.logs-table{ width:100%; border-collapse:collapse; font-size:0.95em; }
+        table.logs-table th, table.logs-table td{ border:1px solid #dee2e6; padding:10px 12px; }
+        table.logs-table th{ background-color:#f8f9fa; color:#495057; font-weight:600; }
+        table.logs-table tr:nth-child(even){ background:#fcfdff; }
+        table.logs-table tr:hover{ background:#eef4f8; }
+        .footer-logo-area{ text-align:center; margin-top:40px; padding-top:25px; border-top:1px solid #e9ecef; }
+        .footer-logo-area img{ max-width:60px; opacity:0.5; }
+    </style>
+</head>
+<body>
+<div class="page-outer-container">
+    <header class="module-header">
+        <div class="header-branding">
+            <a href="dashboard.php" class="header-logo-link"><img src="logo.png" alt="Logo Gruppo Vitolo" class="logo"></a>
+            <div class="header-titles">
+                <h1>Log Azioni</h1>
+                <h2>Area Amministrazione</h2>
+            </div>
+        </div>
+        <div class="user-session-controls">
+            <span><strong><?php echo $username_display; ?></strong> (<?php echo $user_role_display; ?>)</span>
+            <a href="dashboard.php" class="nav-link-button">Dashboard</a>
+            <a href="logout.php" class="logout-button">Logout</a>
+        </div>
+    </header>
+
+    <main class="module-content">
+        <form method="get" action="logs.php" class="filter-form">
+            <div class="filter-group">
+                <label for="user">Utente</label>
+                <input type="text" id="user" name="user" value="<?php echo htmlspecialchars($filter_user); ?>">
+            </div>
+            <div class="filter-group">
+                <label for="action">Azione</label>
+                <input type="text" id="action" name="action" value="<?php echo htmlspecialchars($filter_action); ?>">
+            </div>
+            <div class="filter-group">
+                <label for="from">Da Data</label>
+                <input type="date" id="from" name="from" value="<?php echo htmlspecialchars($filter_from); ?>">
+            </div>
+            <div class="filter-group">
+                <label for="to">A Data</label>
+                <input type="date" id="to" name="to" value="<?php echo htmlspecialchars($filter_to); ?>">
+            </div>
+            <div class="filter-group">
+                <label>&nbsp;</label>
+                <button type="submit" class="nav-link-button" style="background-color:#B08D57;">Filtra</button>
+            </div>
+        </form>
+
+        <?php if ($db_error_message): ?>
+            <p class="error-message"><?php echo $db_error_message; ?></p>
+        <?php else: ?>
+            <table class="logs-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Utente</th>
+                        <th>Azione</th>
+                        <th>Dettagli</th>
+                        <th>Data/Ora</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if (!empty($logs)): ?>
+                        <?php foreach ($logs as $log): ?>
+                            <tr>
+                                <td><?php echo $log['id']; ?></td>
+                                <td><?php echo htmlspecialchars($log['username']); ?></td>
+                                <td><?php echo htmlspecialchars($log['action']); ?></td>
+                                <td><?php echo htmlspecialchars($log['details']); ?></td>
+                                <td><?php echo $log['action_time']; ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    <?php else: ?>
+                        <tr><td colspan="5" style="text-align:center;">Nessun log trovato.</td></tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </main>
+    <footer class="footer-logo-area">
+        <img src="logo.png" alt="Logo Gruppo Vitolo">
+    </footer>
+</div>
+</body>
+</html>

--- a/CRM/order_actions.php
+++ b/CRM/order_actions.php
@@ -2,6 +2,7 @@
 // File: order_actions.php
 session_start();
 require_once 'db_config.php';
+require_once "log_helpers.php";
 
 ob_clean(); 
 header('Content-Type: application/json');
@@ -129,6 +130,7 @@ try {
     $stmt_ordine->close();
 
     $conn->commit();
+    log_action($id_utente_decisione, $_SESSION["username"], "order_$action", "Ordine $order_id dettaglio $detail_id");
     $response = [
         'success' => true,
         'message' => 'Stato aggiornato con successo.',

--- a/CRM/rispondi_a_admin_action.php
+++ b/CRM/rispondi_a_admin_action.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once 'db_config.php';
+require_once "log_helpers.php";
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['user_id'])) {
     header('Location: le_mie_segnalazioni.php?reply=error');
@@ -42,6 +43,7 @@ $success = $stmt->execute();
 $stmt->close();
 
 if ($success) {
+    log_action($_SESSION["user_id"], $_SESSION["username"], "risposta_segnalazione", "Risposta a segnalazione ID " . $row["id_segnalazione"]);
     $upd = $conn->prepare('UPDATE segnalazioni SET data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_segnalazione = ?');
     if ($upd) {
         $upd->bind_param('i', $row['id_segnalazione']);
@@ -53,6 +55,7 @@ if ($success) {
 $conn->close();
 
 if ($success) {
+    log_action($_SESSION["user_id"], $_SESSION["username"], "risposta_segnalazione", "Risposta a segnalazione ID " . $row["id_segnalazione"]);
     header('Location: le_mie_segnalazioni.php?reply=success');
 } else {
     header('Location: le_mie_segnalazioni.php?reply=error');

--- a/CRM/submit_order_action.php
+++ b/CRM/submit_order_action.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once "log_helpers.php";
 
 // Dettagli connessione DB (gli stessi usati negli altri file)
 $db_host = 'localhost';
@@ -113,6 +114,7 @@ try {
 
     // Se tutto è andato a buon fine, committa la transazione
     $conn->commit();
+    log_action($_SESSION["user_id"], $_SESSION["username"], "submit_order", "Ordine ID $id_ordine_inserito");
     error_log("[submit_order_action.php] Transazione completata con successo per ordine #{$id_ordine_inserito}.");
     header("Location: form_page.php?status=order_success");
     exit;

--- a/CRM/submit_segnalazione_action.php
+++ b/CRM/submit_segnalazione_action.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once 'db_config.php';
+require_once "log_helpers.php";
 
 // Sicurezza e validazione
 if ($_SERVER["REQUEST_METHOD"] !== "POST") {
@@ -44,6 +45,7 @@ if ($stmt) {
     $stmt->bind_param("issss", $id_utente, $nome_utente, $titolo, $area_competenza, $descrizione);
     if ($stmt->execute()) {
         // Successo
+        log_action($id_utente, $nome_utente, "submit_segnalazione", "Nuova segnalazione ID " . $conn->insert_id);
         header("Location: segnalazioni_form.php?status=success");
     } else {
         // Errore

--- a/CRM/update_segnalazione_action.php
+++ b/CRM/update_segnalazione_action.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 ini_set('display_errors', 1);
+require_once "log_helpers.php";
 error_reporting(E_ALL);
 require_once 'db_config.php';
 
@@ -59,6 +60,7 @@ try {
     }
 
     $conn->commit();
+    log_action($_SESSION["user_id"], $_SESSION["username"], "update_segnalazione", "Segnalazione $id_segnalazione -> $nuovo_stato");
     echo json_encode(['success' => true, 'message' => 'Segnalazione aggiornata correttamente.']);
 } catch (Exception $e) {
     $conn->rollback();


### PR DESCRIPTION
## Summary
- aggiunto file `log_helpers.php` con funzione per registrare le azioni degli utenti
- creata pagina `logs.php` visibile solo agli admin con filtri per utente, azione e date
- creato nuovo table `user_logs` nello script `db_deploy.sql`
- registrazione delle azioni di login, logout, invio ordini e segnalazioni, gestione ordini e segnalazioni
- aggiunto link alla nuova pagina nel dashboard admin

## Testing
- `php` non presente nel container quindi nessun test eseguibile

------
https://chatgpt.com/codex/tasks/task_b_68468e489270832db24ad130287c20e6