### PR TITLE
Implement chat on orders

### DIFF
--- a/CRM/db_deploy.sql
+++ b/CRM/db_deploy.sql
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS `ordini` (
   `nome_richiedente` varchar(150) NOT NULL,
   `centro_costo` varchar(100) NOT NULL,
   `stato_ordine` varchar(50) NOT NULL DEFAULT 'Inviato',
+  `fattura_file` varchar(255) DEFAULT NULL,
   `data_creazione` timestamp NOT NULL DEFAULT current_timestamp(),
   `data_ultima_modifica` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`id_ordine`),
@@ -99,15 +100,31 @@ CREATE TABLE IF NOT EXISTS `segnalazioni_chat` (
 
 -- Dump dei dati della tabella gruppo_vitolo_db.segnalazioni_chat: ~9 rows (circa)
 INSERT INTO `segnalazioni_chat` (`id`, `id_segnalazione`, `id_utente`, `messaggio_admin`, `risposta_utente`, `data_messaggio`, `data_risposta`) VALUES
-	(1, 3, 1, 'aaa', 'che?', '2025-06-07 21:56:19', '2025-06-07 21:56:29'),
-	(2, 3, 1, 'aaaaaa', 'hai finito?', '2025-06-07 21:56:42', '2025-06-07 21:56:52'),
-	(3, 3, 1, 'non ho parole', '111', '2025-06-07 22:05:57', '2025-06-07 22:08:52'),
-	(4, 3, 1, 'VabbÃ¨ te lo chiudo', ',', '2025-06-07 22:09:23', '2025-06-07 22:10:06'),
-	(5, 4, 1, 'Ciao,\r\nSpecificami il problema nel dettaglio.\r\nGrazie', 'Non si accende, ho controllato anche i cavi.. non so cosa dirti', '2025-06-07 22:11:37', '2025-06-07 22:12:13'),
-	(6, 4, 1, 'Contattato Ufficio IT, in attesa di intervento. Al termine rispondi qui', 'Risolto grazie', '2025-06-07 22:12:34', '2025-06-07 22:12:48'),
-	(7, 4, 1, 'aaa', NULL, '2025-06-07 22:15:33', NULL),
-	(8, 4, 1, 'aaaad2231', NULL, '2025-06-07 22:16:57', NULL),
-	(9, 4, 1, 'adsdasd', NULL, '2025-06-07 22:24:37', NULL);
+        (1, 3, 1, 'aaa', 'che?', '2025-06-07 21:56:19', '2025-06-07 21:56:29'),
+        (2, 3, 1, 'aaaaaa', 'hai finito?', '2025-06-07 21:56:42', '2025-06-07 21:56:52'),
+        (3, 3, 1, 'non ho parole', '111', '2025-06-07 22:05:57', '2025-06-07 22:08:52'),
+        (4, 3, 1, 'VabbÃ¨ te lo chiudo', ',', '2025-06-07 22:09:23', '2025-06-07 22:10:06'),
+        (5, 4, 1, 'Ciao,\r\nSpecificami il problema nel dettaglio.\r\nGrazie', 'Non si accende, ho controllato anche i cavi.. non so cosa dirti', '2025-06-07 22:11:37', '2025-06-07 22:12:13'),
+        (6, 4, 1, 'Contattato Ufficio IT, in attesa di intervento. Al termine rispondi qui', 'Risolto grazie', '2025-06-07 22:12:34', '2025-06-07 22:12:48'),
+        (7, 4, 1, 'aaa', NULL, '2025-06-07 22:15:33', NULL),
+        (8, 4, 1, 'aaaad2231', NULL, '2025-06-07 22:16:57', NULL),
+        (9, 4, 1, 'adsdasd', NULL, '2025-06-07 22:24:37', NULL);
+
+-- Dump della struttura di tabella gruppo_vitolo_db.ordini_chat
+CREATE TABLE IF NOT EXISTS `ordini_chat` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id_ordine` int(11) NOT NULL,
+  `id_utente` int(11) NOT NULL,
+  `messaggio_admin` text DEFAULT NULL,
+  `risposta_utente` text DEFAULT NULL,
+  `data_messaggio` timestamp NOT NULL DEFAULT current_timestamp(),
+  `data_risposta` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `id_ordine` (`id_ordine`),
+  KEY `id_utente` (`id_utente`),
+  CONSTRAINT `ordini_chat_ibfk_1` FOREIGN KEY (`id_ordine`) REFERENCES `ordini` (`id_ordine`) ON DELETE CASCADE,
+  CONSTRAINT `ordini_chat_ibfk_2` FOREIGN KEY (`id_utente`) REFERENCES `utenti` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 -- Dump della struttura di tabella gruppo_vitolo_db.utenti
 CREATE TABLE IF NOT EXISTS `utenti` (

--- a/CRM/delete_fattura_action.php
+++ b/CRM/delete_fattura_action.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+require_once 'db_config.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['ruolo'] !== 'admin') {
+    echo json_encode(['success' => false, 'message' => 'Accesso negato']);
+    exit;
+}
+
+$id_ordine = filter_input(INPUT_POST, 'id_ordine', FILTER_VALIDATE_INT);
+if (!$id_ordine) {
+    echo json_encode(['success' => false, 'message' => 'ID non valido']);
+    exit;
+}
+
+$upload_dir = __DIR__ . '/fatture';
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    echo json_encode(['success' => false, 'message' => 'Errore DB']);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT fattura_file FROM ordini WHERE id_ordine = ?');
+$stmt->bind_param('i', $id_ordine);
+$stmt->execute();
+$stmt->bind_result($file);
+$stmt->fetch();
+$stmt->close();
+
+if ($file && file_exists($upload_dir . '/' . $file)) {
+    unlink($upload_dir . '/' . $file);
+}
+
+$upd = $conn->prepare('UPDATE ordini SET fattura_file = NULL, data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_ordine = ?');
+$upd->bind_param('i', $id_ordine);
+$success = $upd->execute();
+$upd->close();
+$conn->close();
+
+echo json_encode(['success' => $success]);

--- a/CRM/gestioneordini.php
+++ b/CRM/gestioneordini.php
@@ -26,6 +26,7 @@ $filtro_data_a = isset($_GET['data_a']) ? $_GET['data_a'] : '';
 // --- Logica Database (invariato) ---
 $conn_go = isset($db_port) ? new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port) : new mysqli($db_host, $db_user, $db_pass, $db_name);
 $ordini_dal_db = [];
+$chat_messaggi = [];
 $db_error_message_go = null;
 $totale_ordini = 0;
 
@@ -90,6 +91,24 @@ if ($conn_go->connect_error) {
             $ordini_dal_db[] = $ordine_row;
         }
         $stmt_ordini->close();
+
+        if (!empty($ordini_dal_db)) {
+            $ids = array_column($ordini_dal_db, 'id_ordine');
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $types_chat = str_repeat('i', count($ids));
+            $sql_chat = "SELECT id, id_ordine, messaggio_admin, risposta_utente, data_messaggio, data_risposta FROM ordini_chat WHERE id_ordine IN ($placeholders) ORDER BY data_messaggio ASC";
+            $stmt_chat = $conn_go->prepare($sql_chat);
+            $stmt_chat->bind_param($types_chat, ...$ids);
+            $stmt_chat->execute();
+            $res_chat = $stmt_chat->get_result();
+            if ($res_chat) {
+                while ($row = $res_chat->fetch_assoc()) {
+                    $chat_messaggi[$row['id_ordine']][] = $row;
+                }
+                $res_chat->free();
+            }
+            $stmt_chat->close();
+        }
     } else {
         $db_error_message_go = "Errore durante la preparazione degli ordini.";
     }
@@ -172,6 +191,16 @@ if ($conn_go->connect_error) {
         .status-prodotto.approvato { color: #28a745; }
         .status-prodotto.rifiutato { color: #dc3545; }
         .status-prodotto.inviato { color: #007bff; }
+
+        /* Stili chat analoghi alle segnalazioni */
+        .chat-messages { display: flex; flex-direction: column; gap: 8px; max-height: 300px; overflow-y: auto; margin-bottom: 15px; padding-right: 10px; }
+        .chat-message { display: flex; }
+        .chat-message.admin { justify-content: flex-start; }
+        .chat-message.user { justify-content: flex-end; }
+        .bubble { max-width: 75%; padding: 10px 14px; border-radius: 12px; font-size: 0.95em; line-height: 1.4; border: 1px solid transparent; }
+        .chat-message.admin .bubble { background-color: #e9f5ff; border-color: #c3ddf2; border-top-left-radius: 0; color: #034a73; }
+        .chat-message.user .bubble { background-color: #f0fdf4; border-color: #cde7d8; border-top-right-radius: 0; color: #1b4332; }
+        .bubble time { display: block; font-size: 0.75em; color: #6c757d; margin-top: 6px; text-align: right; }
         
         /* --- Paginazione (invariata) --- */
         .pagination-controls { display: flex; justify-content: center; align-items: center; padding: 20px 0; gap: 5px; flex-wrap: wrap; }
@@ -306,6 +335,37 @@ if ($conn_go->connect_error) {
                                 <?php else: ?>
                                     <p>Nessun prodotto in questo ordine.</p>
                                 <?php endif; ?>
+
+                                <?php if (!empty($chat_messaggi[$ordine['id_ordine']])): ?>
+                                    <div class="chat-messages">
+                                        <?php foreach ($chat_messaggi[$ordine['id_ordine']] as $msg): ?>
+                                            <div class="chat-message admin">
+                                                <div class="bubble">
+                                                    <p><?php echo nl2br(htmlspecialchars($msg['messaggio_admin'])); ?></p>
+                                                    <time><?php echo date('d/m H:i', strtotime($msg['data_messaggio'])); ?></time>
+                                                </div>
+                                            </div>
+                                            <?php if (!empty($msg['risposta_utente'])): ?>
+                                                <div class="chat-message user">
+                                                    <div class="bubble">
+                                                        <p><?php echo nl2br(htmlspecialchars($msg['risposta_utente'])); ?></p>
+                                                        <time><?php echo date('d/m H:i', strtotime($msg['data_risposta'])); ?></time>
+                                                    </div>
+                                                </div>
+                                            <?php endif; ?>
+                                        <?php endforeach; ?>
+                                    </div>
+                                <?php endif; ?>
+
+                                <form class="management-form">
+                                    <input type="hidden" name="id_ordine" value="<?php echo $ordine['id_ordine']; ?>">
+                                    <div class="form-group">
+                                        <label for="messaggio_admin-<?php echo $ordine['id_ordine']; ?>">Nuovo Messaggio per l'Utente:</label>
+                                        <textarea id="messaggio_admin-<?php echo $ordine['id_ordine']; ?>" name="messaggio_admin"></textarea>
+                                    </div>
+                                    <button type="button" class="nav-link-button update-chat-btn">Invia</button>
+                                    <span class="update-feedback" style="margin-left:10px;color:green;font-weight:bold;"></span>
+                                </form>
                             </div>
                         </div>
                     <?php endforeach; ?>
@@ -338,7 +398,7 @@ if ($conn_go->connect_error) {
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const ordersListContainer = document.getElementById('orders-list-container');
+        const ordersListContainer = document.getElementById('orders-list-container');
 
     if (ordersListContainer) {
         ordersListContainer.addEventListener('click', function(event) {
@@ -364,6 +424,12 @@ document.addEventListener('DOMContentLoaded', function() {
             if (target.classList.contains('product-action-btn') || target.classList.contains('edit-status-btn')) {
                 event.stopPropagation(); // Evita che il click si propaghi e chiuda/apra l'ordine
                 handleProductAction(target);
+            }
+
+            const chatBtn = target.closest('.update-chat-btn');
+            if (chatBtn) {
+                event.stopPropagation();
+                handleChatSubmit(chatBtn);
             }
         });
     }
@@ -441,6 +507,32 @@ document.addEventListener('DOMContentLoaded', function() {
             orderStatusBadge.textContent = newOrderStatus;
             orderStatusBadge.className = 'status-badge ' + newOrderStatus.toLowerCase().replace(/ /g, '-');
         }
+    }
+
+    function handleChatSubmit(button) {
+        const form = button.closest('.management-form');
+        const id = form.querySelector('input[name="id_ordine"]').value;
+        const msg = form.querySelector('textarea[name="messaggio_admin"]').value;
+        const feedback = form.querySelector('.update-feedback');
+        button.textContent = '...';
+        button.disabled = true;
+        const fd = new FormData();
+        fd.append('id_ordine', id);
+        fd.append('messaggio_admin', msg);
+        fetch('update_order_chat_action.php', {
+            method: 'POST',
+            body: fd
+        }).then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                feedback.textContent = 'Inviato!';
+                setTimeout(() => { feedback.textContent = ''; }, 2000);
+                form.querySelector('textarea[name="messaggio_admin"]').value = '';
+            } else {
+                alert('Errore: ' + data.message);
+            }
+        }).catch(err => { console.error(err); alert('Errore di comunicazione.'); })
+        .finally(() => { button.textContent = 'Invia'; button.disabled = false; });
     }
 });
 </script>

--- a/CRM/i_miei_ordini.php
+++ b/CRM/i_miei_ordini.php
@@ -17,15 +17,16 @@ $user_role_display = htmlspecialchars($_SESSION['ruolo'] ?? 'N/A');
 // --- Logica Database per recuperare gli ordini di QUESTO utente ---
 $conn = new mysqli($db_host, $db_user, $db_pass, $db_name, $db_port ?? 3306);
 $ordini_utente = [];
+$chat_messaggi = [];
 $db_error_message = null;
 
 if ($conn->connect_error) {
     $db_error_message = "Impossibile connettersi al database per caricare lo storico.";
 } else {
     // 1. Prendi tutti gli ordini creati dall'utente loggato
-    $sql_ordini = "SELECT id_ordine, data_richiesta, centro_costo, stato_ordine 
-                   FROM ordini 
-                   WHERE id_utente_richiedente = ? 
+    $sql_ordini = "SELECT id_ordine, data_richiesta, centro_costo, stato_ordine, fattura_file
+                   FROM ordini
+                   WHERE id_utente_richiedente = ?
                    ORDER BY data_richiesta DESC";
     
     $stmt_ordini = $conn->prepare($sql_ordini);
@@ -52,6 +53,24 @@ if ($conn->connect_error) {
         $ordini_utente[] = $ordine_row;
     }
     $stmt_ordini->close();
+
+    if (!empty($ordini_utente)) {
+        $ids = array_column($ordini_utente, 'id_ordine');
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $types = str_repeat('i', count($ids));
+        $sql_chat = "SELECT id, id_ordine, messaggio_admin, risposta_utente, data_messaggio, data_risposta FROM ordini_chat WHERE id_ordine IN ($placeholders) ORDER BY data_messaggio ASC";
+        $stmt_chat = $conn->prepare($sql_chat);
+        $stmt_chat->bind_param($types, ...$ids);
+        $stmt_chat->execute();
+        $res_chat = $stmt_chat->get_result();
+        if ($res_chat) {
+            while ($row = $res_chat->fetch_assoc()) {
+                $chat_messaggi[$row['id_ordine']][] = $row;
+            }
+            $res_chat->free();
+        }
+        $stmt_chat->close();
+    }
     $conn->close();
 }
 ?>
@@ -104,6 +123,17 @@ if ($conn->connect_error) {
         .status-prodotto.Rifiutato { color: #dc3545; }
         .status-prodotto.Inviato { color: #007bff; }
         .status-prodotto.Evaso { color: #6c757d; }
+
+        /* Stili chat */
+        .chat-messages { display: flex; flex-direction: column; gap: 8px; max-height: 300px; overflow-y: auto; margin-bottom: 15px; padding-right: 10px; }
+        .chat-message { display: flex; }
+        .chat-message.admin { justify-content: flex-start; }
+        .chat-message.user { justify-content: flex-end; }
+        .bubble { max-width: 75%; padding: 10px 14px; border-radius: 12px; font-size: 0.95em; line-height: 1.4; border: 1px solid transparent; }
+        .chat-message.admin .bubble { background-color: #e9f5ff; border-color: #c3ddf2; border-top-left-radius: 0; color: #034a73; }
+        .chat-message.user .bubble { background-color: #f0fdf4; border-color: #cde7d8; border-top-right-radius: 0; color: #1b4332; }
+        .bubble time { display: block; font-size: 0.75em; color: #6c757d; margin-top: 6px; text-align: right; }
+        .invoice-download { margin-top: 10px; }
     </style>
 </head>
 <body>
@@ -169,6 +199,39 @@ if ($conn->connect_error) {
                                     <?php endforeach; ?>
                                 <?php else: ?>
                                     <p>Nessun prodotto trovato per questo ordine.</p>
+                                <?php endif; ?>
+
+                                <?php if (!empty($chat_messaggi[$ordine['id_ordine']])): ?>
+                                    <div class="chat-messages">
+                                        <?php foreach ($chat_messaggi[$ordine['id_ordine']] as $msg): ?>
+                                            <div class="chat-message admin">
+                                                <div class="bubble">
+                                                    <p><?php echo nl2br(htmlspecialchars($msg['messaggio_admin'])); ?></p>
+                                                    <time><?php echo date('d/m H:i', strtotime($msg['data_messaggio'])); ?></time>
+                                                </div>
+                                            </div>
+                                            <?php if (empty($msg['risposta_utente']) && $ordine['stato_ordine'] !== 'Evaso'): ?>
+                                                <div class="chat-message user">
+                                                    <form class="bubble reply-form" action="reply_order_chat_action.php" method="POST">
+                                                        <input type="hidden" name="id_messaggio" value="<?php echo $msg['id']; ?>">
+                                                        <textarea name="risposta_utente" placeholder="La tua risposta..." required></textarea>
+                                                        <button type="submit" class="nav-link-button">Invia</button>
+                                                    </form>
+                                                </div>
+                                            <?php elseif (!empty($msg['risposta_utente'])): ?>
+                                                <div class="chat-message user">
+                                                    <div class="bubble">
+                                                        <p><?php echo nl2br(htmlspecialchars($msg['risposta_utente'])); ?></p>
+                                                        <time><?php echo date('d/m H:i', strtotime($msg['data_risposta'])); ?></time>
+                                                    </div>
+                                                </div>
+                                            <?php endif; ?>
+                                        <?php endforeach; ?>
+                                    </div>
+                                <?php endif; ?>
+
+                                <?php if (!empty($ordine['fattura_file'])): ?>
+                                    <p class="invoice-download">Fattura: <a href="fatture/<?php echo rawurlencode($ordine['fattura_file']); ?>" target="_blank" class="nav-link-button">Download</a></p>
                                 <?php endif; ?>
                             </div>
                         </div>

--- a/CRM/reply_order_chat_action.php
+++ b/CRM/reply_order_chat_action.php
@@ -1,0 +1,61 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['user_id'])) {
+    header('Location: i_miei_ordini.php?reply=error');
+    exit;
+}
+
+$id_messaggio = filter_input(INPUT_POST, 'id_messaggio', FILTER_VALIDATE_INT);
+$risposta = trim($_POST['risposta_utente'] ?? '');
+
+if (!$id_messaggio || $risposta === '') {
+    header('Location: i_miei_ordini.php?reply=error');
+    exit;
+}
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    header('Location: i_miei_ordini.php?reply=error');
+    exit;
+}
+
+$sql = 'SELECT oc.id_ordine, oc.risposta_utente, o.id_utente_richiedente FROM ordini_chat oc JOIN ordini o ON oc.id_ordine = o.id_ordine WHERE oc.id = ?';
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('i', $id_messaggio);
+$stmt->execute();
+$result = $stmt->get_result();
+$row = $result->fetch_assoc();
+$stmt->close();
+
+if (!$row || $row['id_utente_richiedente'] != $_SESSION['user_id'] || !empty($row['risposta_utente'])) {
+    $conn->close();
+    header('Location: i_miei_ordini.php?reply=error');
+    exit;
+}
+
+$sql = 'UPDATE ordini_chat SET risposta_utente = ?, data_risposta = CURRENT_TIMESTAMP WHERE id = ?';
+$stmt = $conn->prepare($sql);
+$stmt->bind_param('si', $risposta, $id_messaggio);
+$success = $stmt->execute();
+$stmt->close();
+
+if ($success) {
+    $upd = $conn->prepare('UPDATE ordini SET data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_ordine = ?');
+    if ($upd) {
+        $upd->bind_param('i', $row['id_ordine']);
+        $upd->execute();
+        $upd->close();
+    }
+}
+
+$conn->close();
+
+if ($success) {
+    header('Location: i_miei_ordini.php?reply=success');
+} else {
+    header('Location: i_miei_ordini.php?reply=error');
+}
+exit;
+?>

--- a/CRM/riepilogo_ordini.php
+++ b/CRM/riepilogo_ordini.php
@@ -20,7 +20,7 @@ if ($conn_ro->connect_error) {
     $db_error_message_ro = "Impossibile connettersi al database.";
 } else {
     // 1. TROVA GLI ORDINI CHE CONTENGONO PRODOTTI EVASI
-    $sql_ordini = "SELECT DISTINCT o.id_ordine, o.data_richiesta, o.nome_richiedente, o.centro_costo FROM ordini o JOIN dettagli_ordine do ON o.id_ordine = do.id_ordine WHERE do.stato_prodotto = 'Evaso'";
+    $sql_ordini = "SELECT DISTINCT o.id_ordine, o.data_richiesta, o.nome_richiedente, o.centro_costo, o.fattura_file FROM ordini o JOIN dettagli_ordine do ON o.id_ordine = do.id_ordine WHERE do.stato_prodotto = 'Evaso'";
     $params = [];
     $types = '';
     if (!empty($start_date_filter)) { $sql_ordini .= " AND do.data_evasione >= ?"; $params[] = $start_date_filter . ' 00:00:00'; $types .= 's'; }
@@ -109,6 +109,8 @@ if ($conn_ro->connect_error) {
         .product-detail-item:last-child { border-bottom: none; }
         .product-info .notes { display: block; font-size: 0.9em; color: #6c757d; font-style: italic; }
         .product-meta { text-align: right; font-size: 0.9em; color: #555; }
+        .invoice-section { margin-top: 15px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+        .invoice-section form { display: inline-block; }
         .footer-logo-area { text-align: center; margin-top: 40px; padding-top: 25px; border-top: 1px solid #e9ecef; }
         .footer-logo-area img { max-width: 60px; opacity: 0.5; }
     </style>
@@ -187,6 +189,27 @@ if ($conn_ro->connect_error) {
                                         </div>
                                     <?php endforeach; ?>
                                 <?php endif; ?>
+
+                                <div class="invoice-section">
+                                    <?php if (!empty($ordine['fattura_file'])): ?>
+                                        <p>Fattura: <a href="fatture/<?php echo rawurlencode($ordine['fattura_file']); ?>" target="_blank" class="nav-link-button">Download</a></p>
+                                        <form class="invoice-form" enctype="multipart/form-data" method="POST" action="upload_fattura_action.php">
+                                            <input type="hidden" name="id_ordine" value="<?php echo $ordine['id_ordine']; ?>">
+                                            <input type="file" name="fattura" accept="application/pdf">
+                                            <button type="submit" class="admin-button secondary small">Aggiorna</button>
+                                        </form>
+                                        <form class="delete-invoice-form" method="POST" action="delete_fattura_action.php" onsubmit="return confirm('Eliminare la fattura?');">
+                                            <input type="hidden" name="id_ordine" value="<?php echo $ordine['id_ordine']; ?>">
+                                            <button type="submit" class="admin-button secondary small">Elimina</button>
+                                        </form>
+                                    <?php else: ?>
+                                        <form class="invoice-form" enctype="multipart/form-data" method="POST" action="upload_fattura_action.php">
+                                            <input type="hidden" name="id_ordine" value="<?php echo $ordine['id_ordine']; ?>">
+                                            <input type="file" name="fattura" accept="application/pdf" required>
+                                            <button type="submit" class="admin-button secondary small">Carica Fattura</button>
+                                        </form>
+                                    <?php endif; ?>
+                                </div>
                             </div>
                         </div>
                     <?php endforeach; ?>
@@ -206,6 +229,25 @@ if ($conn_ro->connect_error) {
             summary.addEventListener('click', function() {
                 const orderRecord = this.closest('.order-record');
                 orderRecord.classList.toggle('active');
+            });
+        });
+
+        document.querySelectorAll('.invoice-form').forEach(form => {
+            form.addEventListener('submit', function(e) {
+                e.preventDefault();
+                const fd = new FormData(form);
+                fetch('upload_fattura_action.php', { method: 'POST', body: fd })
+                    .then(r => r.json()).then(() => location.reload());
+            });
+        });
+
+        document.querySelectorAll('.delete-invoice-form').forEach(form => {
+            form.addEventListener('submit', function(e) {
+                e.preventDefault();
+                if (!confirm('Eliminare la fattura?')) return;
+                const fd = new FormData(form);
+                fetch('delete_fattura_action.php', { method: 'POST', body: fd })
+                    .then(r => r.json()).then(() => location.reload());
             });
         });
     });

--- a/CRM/update_order_chat_action.php
+++ b/CRM/update_order_chat_action.php
@@ -1,0 +1,43 @@
+<?php
+session_start();
+require_once 'db_config.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['ruolo'] !== 'admin') {
+    echo json_encode(['success' => false, 'message' => 'Accesso non autorizzato.']);
+    exit;
+}
+
+$id_ordine = filter_input(INPUT_POST, 'id_ordine', FILTER_VALIDATE_INT);
+$messaggio = trim($_POST['messaggio_admin'] ?? '');
+
+if (!$id_ordine || $messaggio === '') {
+    echo json_encode(['success' => false, 'message' => 'Dati non validi.']);
+    exit;
+}
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    echo json_encode(['success' => false, 'message' => 'Errore di connessione al database.']);
+    exit;
+}
+
+$stmt = $conn->prepare("INSERT INTO ordini_chat (id_ordine, id_utente, messaggio_admin, data_messaggio) VALUES (?, ?, ?, CURRENT_TIMESTAMP)");
+$admin_id = $_SESSION['user_id'];
+$stmt->bind_param('iis', $id_ordine, $admin_id, $messaggio);
+$success = $stmt->execute();
+$stmt->close();
+
+if ($success) {
+    $upd = $conn->prepare("UPDATE ordini SET data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_ordine = ?");
+    $upd->bind_param('i', $id_ordine);
+    $upd->execute();
+    $upd->close();
+}
+
+$conn->close();
+
+echo json_encode(['success' => $success]);
+exit;
+?>

--- a/CRM/upload_fattura_action.php
+++ b/CRM/upload_fattura_action.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+require_once 'db_config.php';
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || $_SESSION['ruolo'] !== 'admin') {
+    echo json_encode(['success' => false, 'message' => 'Accesso negato']);
+    exit;
+}
+
+$id_ordine = filter_input(INPUT_POST, 'id_ordine', FILTER_VALIDATE_INT);
+if (!$id_ordine || !isset($_FILES['fattura'])) {
+    echo json_encode(['success' => false, 'message' => 'Dati non validi']);
+    exit;
+}
+
+$upload_dir = __DIR__ . '/fatture';
+if (!is_dir($upload_dir)) {
+    mkdir($upload_dir, 0777, true);
+}
+
+$conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
+if ($conn->connect_error) {
+    echo json_encode(['success' => false, 'message' => 'Errore DB']);
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT fattura_file FROM ordini WHERE id_ordine = ?');
+$stmt->bind_param('i', $id_ordine);
+$stmt->execute();
+$stmt->bind_result($current_file);
+$stmt->fetch();
+$stmt->close();
+
+$original = basename($_FILES['fattura']['name']);
+$ext = pathinfo($original, PATHINFO_EXTENSION);
+$filename = 'ordine_' . $id_ordine . ($ext ? '.' . $ext : '');
+$dest = $upload_dir . '/' . $filename;
+
+if (!move_uploaded_file($_FILES['fattura']['tmp_name'], $dest)) {
+    echo json_encode(['success' => false, 'message' => 'Impossibile salvare il file']);
+    $conn->close();
+    exit;
+}
+
+if ($current_file && $current_file !== $filename && file_exists($upload_dir . '/' . $current_file)) {
+    unlink($upload_dir . '/' . $current_file);
+}
+
+$upd = $conn->prepare('UPDATE ordini SET fattura_file = ?, data_ultima_modifica = CURRENT_TIMESTAMP WHERE id_ordine = ?');
+$upd->bind_param('si', $filename, $id_ordine);
+$success = $upd->execute();
+$upd->close();
+$conn->close();
+
+echo json_encode(['success' => $success]);


### PR DESCRIPTION
## Summary
- add `ordini_chat` table in db schema
- enable order chat retrieval/management in admin page
- show chat thread and reply form on user orders page
- add actions to insert admin messages and user replies
- add invoice upload and management for each order

## Testing
- `php -l CRM/riepilogo_ordini.php` *(fails: php not installed)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6846aa8321bc832da2e3a9d466f5713a