### PR TITLE
Implement user-friendly logging

### DIFF
--- a/CRM/dashboard.php
+++ b/CRM/dashboard.php
@@ -1,14 +1,13 @@
 <?php
 session_start();
+require_once 'logger.php';
 
 // --- Blocco Debug e Configurazione Sessione/Log ---
 ini_set('log_errors', 1);
-ini_set('error_log', 'C:/xampp/php_error.log');
 error_reporting(E_ALL);
-ini_set('display_errors', 0); 
+ini_set('display_errors', 0);
 
-$timestamp = date("Y-m-d H:i:s");
-error_log("--- [{$timestamp}] Accesso a dashboard.php ---");
+logUserAction("Accesso alla dashboard dell'utente '" . ($_SESSION['username'] ?? 'N/A') . "'");
 
 // Blocco di sicurezza flessibile
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {

--- a/CRM/form_page.php
+++ b/CRM/form_page.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'logger.php';
 
 // Verifica se l'utente è loggato, altrimenti reindirizza alla pagina di login
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
@@ -42,7 +43,7 @@ if (isset($_GET['status'])) {
 $timestamp = date("Y-m-d H:i:s");
 ini_set('log_errors', 1); 
 ini_set('error_log', 'C:/xampp/php_error.log');
-error_log("--- [{$timestamp}] Accesso a form_page.php UTENTE: " . htmlspecialchars($_SESSION['username']) . " ---");
+logUserAction("Accesso alla pagina richiesta acquisti da parte di '" . ($_SESSION['username'] ?? 'N/A') . "'");
 
 ?>
 <!DOCTYPE html>

--- a/CRM/gestioneutenze.php
+++ b/CRM/gestioneutenze.php
@@ -1,20 +1,20 @@
 <?php
 session_start();
+require_once 'logger.php';
 
 // --- Blocco Debug e Configurazione Sessione/Log ---
 ini_set('log_errors', 1);
-ini_set('error_log', 'C:/xampp/php_error.log');
 error_reporting(E_ALL);
 
 $timestamp = date("Y-m-d H:i:s");
 $ruolo_admin_atteso = 'admin';
 
 $action_for_log = isset($_GET['action']) ? $_GET['action'] : 'list';
-error_log("--- [{$timestamp}] Accesso a gestioneutenze.php (View: {$action_for_log}) UTENTE: " . (isset($_SESSION['username']) ? $_SESSION['username'] : 'NON LOGGATO') . " ---");
+logUserAction("Accesso a gestione utenze (view: {$action_for_log}) da parte di '" . ($_SESSION['username'] ?? 'NON LOGGATO') . "'");
 
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || 
     !isset($_SESSION['ruolo']) || $_SESSION['ruolo'] !== $ruolo_admin_atteso) {
-    error_log("--- [{$timestamp}] Accesso NEGATO a gestioneutenze.php (non admin o non loggato) ---");
+    logUserAction("Accesso negato a gestione utenze per utente non autorizzato");
     header("Location: login.php");
     exit;
 }
@@ -34,7 +34,7 @@ $user_id_to_edit = null;
 $user_to_edit = null;
 
 if ($conn_gu->connect_error) {
-    error_log("[gestioneutenze.php] Errore connessione DB: " . $conn_gu->connect_error);
+    logUserAction("Errore di connessione al DB durante la gestione utenze: " . $conn_gu->connect_error);
     $db_error_message = "Impossibile caricare i dati: errore di connessione al database.";
 } else {
     $sql_users = "SELECT id, username, email, nome, ruolo, data_creazione FROM utenti ORDER BY username ASC";
@@ -43,7 +43,7 @@ if ($conn_gu->connect_error) {
         while ($row = $result_users->fetch_assoc()) { $users_list[] = $row; }
         $result_users->free();
     } else {
-        error_log("[gestioneutenze.php] Errore query lista utenti: " . $conn_gu->error);
+        logUserAction("Errore nell'esecuzione della query lista utenti: " . $conn_gu->error);
         $db_error_message = "Errore nel caricamento della lista utenti.";
     }
 
@@ -56,14 +56,14 @@ if ($conn_gu->connect_error) {
             $result_edit = $stmt_edit->get_result();
             $user_to_edit = $result_edit->fetch_assoc();
             if (!$user_to_edit) {
-                error_log("[gestioneutenze.php] Tentativo di modifica utente ID {$user_id_to_edit} non trovato.");
+                logUserAction("Modifica utente fallita: ID {$user_id_to_edit} non trovato");
                 $_SESSION['error_message_usermgmt'] = "Utente da modificare non trovato (ID: ".htmlspecialchars($user_id_to_edit).").";
                  header("Location: gestioneutenze.php?action=list_feedback"); 
                  exit;
             }
             $stmt_edit->close();
         } else {
-             error_log("[gestioneutenze.php] Errore preparazione statement per modifica utente: " . $conn_gu->error);
+             logUserAction("Errore preparazione statement per modifica utente: " . $conn_gu->error);
              $db_error_message = "Errore nel caricamento dati utente per modifica.";
              $action = 'list';
         }

--- a/CRM/logger.php
+++ b/CRM/logger.php
@@ -1,0 +1,8 @@
+<?php
+function logUserAction($message) {
+    $logFile = __DIR__ . '/user_actions.log';
+    $timestamp = date('Y-m-d H:i:s');
+    $entry = "[{$timestamp}] {$message}\n";
+    file_put_contents($logFile, $entry, FILE_APPEND);
+}
+?>

--- a/CRM/login.php
+++ b/CRM/login.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'logger.php';
 
 if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] === true) {
     header("Location: dashboard.php");
@@ -17,18 +18,18 @@ $db_pass = '';
 $db_name = 'gruppo_vitolo_db';
 $login_error = '';
 
-error_log("--- Inizio tentativo di login (con ruoli) --- [" . date("Y-m-d H:i:s") . "]");
+logUserAction("Tentativo di login avviato");
 
 if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) {
     $username_input = trim($_POST['username']);
     $password_input = $_POST['password'];
 
-    error_log("[Login con ruoli] Input ricevuto - Username: [{$username_input}]");
+    logUserAction("Tentativo di login per utente '{$username_input}'");
 
     $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
 
     if ($conn->connect_error) {
-        error_log("[Login con ruoli] Errore di connessione al database: " . $conn->connect_error);
+        logUserAction("Errore di connessione al database durante login utente '{$username_input}': " . $conn->connect_error);
         $login_error = "Errore di sistema. Riprova più tardi.";
     } else {
         $stmt = $conn->prepare("SELECT id, username, password_hash, ruolo, nome FROM utenti WHERE username = ?");
@@ -48,13 +49,16 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) {
                         $_SESSION['username'] = $db_username;
                         $_SESSION['ruolo'] = $db_ruolo;
                         $_SESSION['user_fullname'] = $db_user_fullname;
+                        logUserAction("Login riuscito per utente '{$db_username}' con ruolo '{$db_ruolo}'");
                         header("Location: dashboard.php");
                         exit;
                     } else {
                         $login_error = "Nome utente o password non validi.";
+                        logUserAction("Login fallito per utente '{$username_input}': password errata");
                     }
                 } else {
                     $login_error = "Nome utente o password non validi.";
+                    logUserAction("Login fallito per utente '{$username_input}': utente non trovato");
                 }
             }
             $stmt->close();
@@ -64,7 +68,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_POST['login'])) {
         $conn->close();
     }
 }
-error_log("--- Fine tentativo di login (con ruoli) --- [" . date("Y-m-d H:i:s") . "]");
+logUserAction("Fine tentativo di login");
 ?>
 
 <!DOCTYPE html>

--- a/CRM/order_actions.php
+++ b/CRM/order_actions.php
@@ -1,6 +1,7 @@
 <?php
 // File: order_actions.php
 session_start();
+require_once 'logger.php';
 require_once 'db_config.php';
 
 ob_clean(); 
@@ -43,7 +44,7 @@ $conn = isset($db_port)
 
 if ($conn->connect_error) {
     $response['message'] = 'Errore di connessione al database.';
-    error_log("[order_actions.php] Errore connessione DB: " . $conn->connect_error);
+    logUserAction("Errore connessione DB in order_actions: " . $conn->connect_error);
     ob_end_clean();
     echo json_encode($response);
     exit;
@@ -139,7 +140,7 @@ try {
 } catch (Exception $e) {
     $conn->rollback();
     $response['message'] = $e->getMessage();
-    error_log("[order_actions.php] ERRORE TRANSAZIONE: " . $e->getMessage());
+    logUserAction("Errore transazione in order_actions: " . $e->getMessage());
 } finally {
     if ($conn) $conn->close();
 }

--- a/CRM/submit_order_action.php
+++ b/CRM/submit_order_action.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'logger.php';
 
 // Dettagli connessione DB (gli stessi usati negli altri file)
 $db_host = 'localhost';
@@ -15,19 +16,19 @@ $timestamp = date("Y-m-d H:i:s");
 
 // Verifica che l'utente sia loggato
 if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true || !isset($_SESSION['user_id'])) {
-    error_log("--- [{$timestamp}] [submit_order_action.php] Tentativo di invio ordine da utente non loggato o sessione invalida. ---");
+    logUserAction("Tentativo di invio ordine da utente non loggato o con sessione invalida");
     header("Location: login.php?error=session_expired");
     exit;
 }
 
 // Verifica che la richiesta sia POST
 if ($_SERVER["REQUEST_METHOD"] !== "POST") {
-    error_log("--- [{$timestamp}] [submit_order_action.php] Accesso non POST al file. ---");
+    logUserAction("Accesso non POST a submit_order_action.php da parte di '" . ($_SESSION['username'] ?? 'N/A') . "'");
     header("Location: form_page.php?status=order_error&message=" . urlencode("Metodo di richiesta non valido."));
     exit;
 }
 
-error_log("--- [{$timestamp}] [submit_order_action.php] Ricevuta richiesta POST per invio ordine. Utente ID: {$_SESSION['user_id']} ---");
+logUserAction("Richiesta di invio ordine ricevuta dall'utente ID {$_SESSION['user_id']}");
 
 // Recupero e validazione dati principali del form
 $id_utente_richiedente = filter_var($_POST['id_utente_richiedente'] ?? $_SESSION['user_id'], FILTER_VALIDATE_INT);
@@ -38,13 +39,13 @@ $prodotti = json_decode($prodotti_json, true); // Decodifica in array PHP
 
 // Validazione base
 if (empty($id_utente_richiedente) || empty($nome_richiedente) || empty($centro_costo)) {
-    error_log("[submit_order_action.php] Dati mancanti: id_utente, nome_richiedente o centro_costo.");
+    logUserAction("Invio ordine fallito: dati principali mancanti");
     header("Location: form_page.php?status=order_error&message=" . urlencode("Dati principali mancanti."));
     exit;
 }
 
 if (empty($prodotti) || !is_array($prodotti)) {
-    error_log("[submit_order_action.php] Nessun prodotto inviato o formato JSON prodotti errato.");
+    logUserAction("Invio ordine fallito: nessun prodotto o JSON non valido");
     header("Location: form_page.php?status=order_error&message=" . urlencode("Nessun prodotto specificato nella richiesta."));
     exit;
 }
@@ -56,7 +57,7 @@ $data_richiesta_sql = date('Y-m-d H:i:s');
 // Connessione al database
 $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
 if ($conn->connect_error) {
-    error_log("[submit_order_action.php] Errore connessione DB: " . $conn->connect_error);
+    logUserAction("Errore connessione DB durante invio ordine: " . $conn->connect_error);
     header("Location: form_page.php?status=order_error&message=" . urlencode("Errore di connessione al database."));
     exit;
 }
@@ -84,7 +85,7 @@ try {
     if (!$id_ordine_inserito) {
         throw new Exception("Impossibile recuperare l'ID dell'ordine inserito.");
     }
-    error_log("[submit_order_action.php] Ordine #{$id_ordine_inserito} inserito con successo.");
+    logUserAction("Ordine #{$id_ordine_inserito} inserito con successo");
 
     // 2. Inserisci i dettagli dell'ordine (prodotti) nella tabella 'dettagli_ordine'
     $stmt_dettaglio = $conn->prepare("INSERT INTO dettagli_ordine (id_ordine, nome_prodotto, quantita, unita_misura, note_prodotto, stato_prodotto) VALUES (?, ?, ?, ?, ?, ?)");
@@ -107,20 +108,20 @@ try {
         if (!$stmt_dettaglio->execute()) {
             throw new Exception("Errore esecuzione statement dettaglio prodotto: " . $stmt_dettaglio->error . " per prodotto: " . $nome_p);
         }
-        error_log("[submit_order_action.php] Dettaglio prodotto '{$nome_p}' per ordine #{$id_ordine_inserito} inserito.");
+        logUserAction("Inserito dettaglio prodotto '{$nome_p}' per ordine #{$id_ordine_inserito}");
     }
     $stmt_dettaglio->close();
 
     // Se tutto è andato a buon fine, committa la transazione
     $conn->commit();
-    error_log("[submit_order_action.php] Transazione completata con successo per ordine #{$id_ordine_inserito}.");
+    logUserAction("Transazione completata per ordine #{$id_ordine_inserito}");
     header("Location: form_page.php?status=order_success");
     exit;
 
 } catch (Exception $e) {
     // Qualcosa è andato storto, annulla la transazione
     $conn->rollback();
-    error_log("[submit_order_action.php] ERRORE TRANSAZIONE: " . $e->getMessage());
+    logUserAction("Errore transazione in submit_order_action: " . $e->getMessage());
     // Reindirizza con un messaggio di errore più specifico se possibile, o uno generico
     $error_message_url = urlencode("Si è verificato un errore durante il salvataggio dell'ordine: " . $e->getMessage());
     header("Location: form_page.php?status=order_error&message=" . $error_message_url);

--- a/CRM/submit_segnalazione_action.php
+++ b/CRM/submit_segnalazione_action.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once 'logger.php';
 require_once 'db_config.php';
 
 // Sicurezza e validazione
@@ -30,7 +31,7 @@ if (empty($titolo) || empty($area_competenza) || empty($descrizione)) {
 // Connessione al DB
 $conn = new mysqli($db_host, $db_user, $db_pass, $db_name);
 if ($conn->connect_error) {
-    error_log("Errore connessione DB in submit_segnalazione_action: " . $conn->connect_error);
+    logUserAction("Errore connessione DB durante invio segnalazione: " . $conn->connect_error);
     $error_msg = urlencode("Errore di connessione al sistema.");
     header("Location: segnalazioni_form.php?status=error&message=$error_msg");
     exit;
@@ -47,13 +48,13 @@ if ($stmt) {
         header("Location: segnalazioni_form.php?status=success");
     } else {
         // Errore
-        error_log("Errore esecuzione statement in submit_segnalazione_action: " . $stmt->error);
+        logUserAction("Errore nell'esecuzione della query per salvare la segnalazione: " . $stmt->error);
         $error_msg = urlencode("Impossibile salvare la segnalazione.");
         header("Location: segnalazioni_form.php?status=error&message=$error_msg");
     }
     $stmt->close();
 } else {
-    error_log("Errore preparazione statement in submit_segnalazione_action: " . $conn->error);
+    logUserAction("Errore preparazione statement per salvare la segnalazione: " . $conn->error);
     $error_msg = urlencode("Errore di sistema interno.");
     header("Location: segnalazioni_form.php?status=error&message=$error_msg");
 }


### PR DESCRIPTION
## Summary
- create new `logUserAction` helper
- log user actions in login, dashboard, and form pages
- add friendly logs for user management and order APIs

## Testing
- `php` not installed; unable to run lint tests

------
https://chatgpt.com/codex/tasks/task_b_6846b745c170832d91e8e8e4927200b5